### PR TITLE
jsonschema.validate fix to enable required properties

### DIFF
--- a/schemapi/codegen.py
+++ b/schemapi/codegen.py
@@ -222,7 +222,7 @@ class SchemaModuleGenerator(object):
 
     def _validate(self):
         metaschema = load_metaschema()
-        jsonschema.validate(metaschema, self.schema)
+        jsonschema.validate(self.schema, metaschema)
 
     def module_code(self):
         """Generate a Python module implementing the schema"""

--- a/schemapi/tests/test_codegen.py
+++ b/schemapi/tests/test_codegen.py
@@ -13,13 +13,16 @@ def schema():
                 }
             }
         },
-        'additionalProperties'
         'properties': {
+            'family_name': {
+                'type': 'string'
+            },
             'people': {
                 'type': 'array',
                 'items': {'$ref': '#/definitions/Person'}
             }
-        }
+        },
+        'required': ['family_name']
     }
 
 
@@ -36,9 +39,9 @@ def test_module_code(schema):
     assert issubclass(Family, SchemaBase)
     assert issubclass(Person, SchemaBase)
 
-    family = Family(people=[Person(name='Alice', age=25), Person(name='Bob', age=26)])
+    family = Family(family_name='Smith', people=[Person(name='Alice', age=25), Person(name='Bob', age=26)])
     dct = family.to_dict()
-    assert dct == {'people': [{'name': 'Alice', 'age': 25}, {'name': 'Bob', 'age': 26}]}
+    assert dct == {'family_name': 'Smith', 'people': [{'name': 'Alice', 'age': 25}, {'name': 'Bob', 'age': 26}]}
     family2 = Family.from_dict(dct)
     assert family2.to_dict() == dct
 
@@ -53,8 +56,8 @@ def test_dynamic_module(schema):
     assert issubclass(Family, SchemaBase)
     assert issubclass(Person, SchemaBase)
 
-    family = Family(people=[Person(name='Alice', age=25), Person(name='Bob', age=26)])
+    family = Family(family_name='Smith', people=[Person(name='Alice', age=25), Person(name='Bob', age=26)])
     dct = family.to_dict()
-    assert dct == {'people': [{'name': 'Alice', 'age': 25}, {'name': 'Bob', 'age': 26}]}
+    assert dct == {'family_name': 'Smith', 'people': [{'name': 'Alice', 'age': 25}, {'name': 'Bob', 'age': 26}]}
     family2 = Family.from_dict(dct)
     assert family2.to_dict() == dct


### PR DESCRIPTION
in codegen.SchemaModuleGenerator._validate
the arguments for jsonschema.validate were in the wrong order (bug fix)
after fixing this, we can add 'required' as an element in the domain schema (see codegen test)