### PR TITLE
Fix failure on missing properties while building docstrings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-from .schemapi import *

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .schemapi import *

--- a/schemapi/codegen.py
+++ b/schemapi/codegen.py
@@ -151,9 +151,10 @@ class SchemaClassGenerator(object):
                     '----------',
                     '']
             for prop in sorted(required) + sorted(kwds) + sorted(invalid_kwds):
-                propinfo = info.properties[prop]
-                doc += ["{} : {}".format(prop, propinfo.short_description),
-                        "    {}".format(self._process_description(propinfo.description))]
+                    if prop in info.properties:
+                        propinfo = info.properties[prop]
+                        doc += ["{} : {}".format(prop, propinfo.short_description),
+                                "    {}".format(self._process_description(propinfo.description))]
         if len(doc) > 1:
             doc += ['']
         return indent_docstring(doc, indent_level=indent, width=100, lstrip=True)


### PR DESCRIPTION
I was running into issues where failing to define "description" on individual properties was failing, this commit resolves. 

Additionally, this commit adds an `__init__.py` to the root of the project directory to allow use of `python setup.py develop` in addition to `pip install .`